### PR TITLE
Corrige funcionamento da extensão prevenindo que a injeção de urls fora da política de CORS

### DIFF
--- a/MapDark.user.js
+++ b/MapDark.user.js
@@ -13,41 +13,45 @@
 // @run-at       document-start
 // ==/UserScript==
 
+const themesUrlMap = {
+    liberty: {
+        url: "https://maps.wplace.live/styles/liberty",
+        iconColor: "#000000",
+        buttonBackground: "#ffffff",
+        name: "Liberty",
+    },
+    dark: {
+        url: "https://maps.wplace.live/styles/dark",
+        iconColor: "#ffffff",
+        buttonBackground: "#000000",
+        name: "Dark",
+    },
+    bright: {
+        url: "https://maps.wplace.live/styles/bright",
+        iconColor: "#000000",
+        buttonBackground: "#ffffff",
+        name: "Bright",
+    },
+};
+
+const defaultTheme = "liberty";
+const originalThemeUrlRe = /^https:\/\/maps\.wplace\.live\/styles\/\w+$/;
+
 (async function() {
     'use strict';
 
-    let mapTheme = localStorage.getItem("MapTheme");
-    if (mapTheme === null) {
-        mapTheme = 'liberty';
-    }
+    const storedMapTheme = localStorage.getItem("MapTheme");
+
+    const mapTheme = storedMapTheme in themesUrlMap ? storedMapTheme : defaultTheme
+
+    const selectedTheme = themesUrlMap[mapTheme]
 
     const originalFetch = unsafeWindow.fetch;
-    unsafeWindow.fetch = async (...arg) => {
-        if (arg[0]?.url === "https://tiles.openfreemap.org/styles/liberty") {
-            let url;
-            switch (mapTheme) {
-                case "liberty":
-                    url = "https://tiles.openfreemap.org/styles/liberty";
-                    break;
-                case "dark":
-                    url = "https://tiles.openfreemap.org/styles/dark";
-                    break;
-                case "fiord":
-                    url = "https://tiles.openfreemap.org/styles/fiord";
-                    break;
-                case "positron":
-                    url = "https://tiles.openfreemap.org/styles/positron";
-                    break;
-                case "bright":
-                    url = "https://tiles.openfreemap.org/styles/bright";
-                    break;
-                default:
-                    url = arg[0]?.url;
-                    break;
-            }
-            return originalFetch(url);
+    unsafeWindow.fetch = async (configArg, ...restArg) => {
+        if (originalThemeUrlRe.test(configArg?.url)) {
+            return originalFetch(selectedTheme.url);
         } else {
-            return originalFetch(...arg);
+            return originalFetch(configArg, ...restArg);
         }
     };
 
@@ -57,52 +61,22 @@
         window.location.reload();
     }
 
-    const observer = new MutationObserver((changes, observer) => {
+    const observer = new MutationObserver((_, observer) => {
         const selector = document.querySelector("div.flex.flex-col.items-center.gap-3");
         if (selector) {
             observer.disconnect();
 
-            let svgFill = "#000000";
-            let btnBackgroundColor = null;
-            switch (mapTheme) {
-                case "bright":
-                case "liberty":
-                    svgFill = "#000000";
-                    btnBackgroundColor = "#ffffff";
-                    break;
-                case "dark":
-                    svgFill = "#ffffff";
-                    btnBackgroundColor = "#000000";
-                    break;
-                case "positron":
-                    svgFill = "#000000";
-                    btnBackgroundColor = "#c3c8ca";
-                    break;
-                case "fiord":
-                    svgFill = "#ffffff";
-                    btnBackgroundColor = "#000055";
-                    break;
-            }
-
-            const builtInThemes = [
-                { id: 'dark', name: 'Dark' },
-                { id: 'fiord', name: 'Fiord' },
-                { id: 'liberty', name: 'Liberty' },
-                { id: 'bright', name: 'Bright' },
-                { id: 'positron', name: 'Positron' }
-            ];
-
-            let menuItemsHTML = builtInThemes.map(theme => {
-                const activeClass = mapTheme === theme.id ? 'active' : '';
-                return `<li><a class="${activeClass}" data-theme="${theme.id}" onclick="window.changeMapTheme(event);">${theme.name}</a></li>`;
+            let menuItemsHTML = Object.entries(themesUrlMap).map(([id, theme]) => {
+                const activeClass = mapTheme === id ? 'active' : '';
+                return `<li><a class="${activeClass}" data-theme="${id}" onclick="window.changeMapTheme(event);">${theme.name}</a></li>`;
             }).join('');
 
             const element = document.createElement("div");
             selector.appendChild(element);
             element.outerHTML = `
         <div class="dropdown dropdown-end">
-            <button id="map-theme-btn" class="btn btn-square relative shadow-md" tabindex="0" title="Map Theme" style="background-color: ${btnBackgroundColor}">
-                <svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="${svgFill}">
+            <button id="map-theme-btn" class="btn btn-square relative shadow-md" tabindex="0" title="Map Theme" style="background-color: ${selectedTheme.buttonBackground}">
+                <svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="${selectedTheme.iconColor}">
                     <path d="M12 11.807A9.002 9.002 0 0 1 10.049 2a9.942 9.942 0 0 0-5.12 2.735c-3.905 3.905-3.905 10.237 0 14.142 3.906 3.906 10.237 3.905 14.143 0a9.946 9.946 0 0 0 2.735-5.119A9.003 9.003 0 0 1 12 11.807z"/>
                 </svg>
             </button>

--- a/MapDark.user.js
+++ b/MapDark.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Map Dark
 // @namespace    https://github.com/autergame/
-// @version      1.0.1
+// @version      1.0.2
 // @description  Modify wplace.live map with theme selection
 // @author       Auter
 // @license      MIT

--- a/MapDark.user.js
+++ b/MapDark.user.js
@@ -13,7 +13,7 @@
 // @run-at       document-start
 // ==/UserScript==
 
-const themesUrlMap = {
+const themesMap = {
     liberty: {
         url: "https://maps.wplace.live/styles/liberty",
         iconColor: "#000000",
@@ -42,9 +42,9 @@ const originalThemeUrlRe = /^https:\/\/maps\.wplace\.live\/styles\/\w+$/;
 
     const storedMapTheme = localStorage.getItem("MapTheme");
 
-    const mapTheme = storedMapTheme in themesUrlMap ? storedMapTheme : defaultTheme
+    const mapTheme = storedMapTheme in themesMap ? storedMapTheme : defaultTheme
 
-    const selectedTheme = themesUrlMap[mapTheme]
+    const selectedTheme = themesMap[mapTheme]
 
     const originalFetch = unsafeWindow.fetch;
     unsafeWindow.fetch = async (configArg, ...restArg) => {
@@ -66,7 +66,7 @@ const originalThemeUrlRe = /^https:\/\/maps\.wplace\.live\/styles\/\w+$/;
         if (selector) {
             observer.disconnect();
 
-            let menuItemsHTML = Object.entries(themesUrlMap).map(([id, theme]) => {
+            let menuItemsHTML = Object.entries(themesMap).map(([id, theme]) => {
                 const activeClass = mapTheme === id ? 'active' : '';
                 return `<li><a class="${activeClass}" data-theme="${id}" onclick="window.changeMapTheme(event);">${theme.name}</a></li>`;
             }).join('');


### PR DESCRIPTION
A extensão parou de funcionar por conta da política de CORS do site que não permite mais fazer fetch de urls <kbd>openfreemap.org</kbd>, agora os temas estão vindo de <kbd>maps.wplace.live/styles/</kbd> mas infelizmente os temas `bright` e `positron` ( :octocat: https://github.com/autergame/WplacePlugins/pull/1), eu estava usando positron btw 😢, não estão nessa url.

Existem formas de burlar isso fazendo a req pelo Tampermonkey mas envolve muita engenharia pra pouca solução, e eu não adicionaria isso, ou se adicionasse junto com uma forma de avisar o usuário que ele pode tomar um ban ao tentar burlar os CORS usando aquele tema externo

aproveitei pra dar umas refatorada tbm ;D reaproveitar algumas coisas que estavam bem repetidas

